### PR TITLE
Grunt 0.4 doesn't output to stderr so error messages are lost

### DIFF
--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -14,7 +14,10 @@ module.exports = function(grunt) {
 
     grunt.util.spawn(task, function(error, result, code) {
       if (error || code !== 0) {
-        grunt.log.error(result, error.message);
+        grunt.log.error(result.stderr || result.stdout);
+        if (error.message) {
+          grunt.log(error.message);
+        }
         return deferred.reject();
       }
 


### PR DESCRIPTION
According to gruntjs/grunt/pull/570 `Grunt` won't output error messages to `stderr` until 0.5.

This means `grunt-parallel` loses task error messages unless `opts: { stdio: 'inherit' }` is used. 

Instead of relying on `stderr` this fix uses `stderr` or `stdout`.

In addition `grunt.log.error` only takes on argument, so `result.message` would not get logged. This has been fixed as well.
