### PR TITLE
Log intermediate output from stdout and stderr

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,33 @@ module.exports = function(grunt) {
     grunt.log.write('Blocking finished.');
   });
 
+  //Tasks that log intermediate output
+  grunt.registerTask('log500', function() {
+    var done = this.async();
+    var i = 0;
+    var interval = setInterval(function () {
+      console.log('500', i);
+      i++;
+      if (i > 10) {
+        clearInterval(interval);
+        done();
+      }
+    }, 500);
+  });
+
+  grunt.registerTask('log1000', function() {
+    var done = this.async();
+    var i = 0;
+    var interval = setInterval(function () {
+      console.log('1000', i);
+      i++;
+      if (i > 10) {
+        clearInterval(interval);
+        done();
+      }
+    }, 1000);
+  });
+
   // Project configuration.
   grunt.initConfig({
     parallel: {
@@ -23,6 +50,13 @@ module.exports = function(grunt) {
       },{
         grunt: true,
         args: ['fast']
+      }],
+      longrunning: [{
+        grunt: true,
+        args: ['log500']
+      }, {
+        grunt: true,
+        args: ['log1000']
       }]
     }
   });

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -12,18 +12,24 @@ module.exports = function(grunt) {
   function spawn(task) {
     var deferred = Q.defer();
 
-    grunt.util.spawn(task, function(error, result, code) {
+    ps = grunt.util.spawn(task, function(error, result, code) {
       if (error || code !== 0) {
-        grunt.log.error(result.stderr || result.stdout);
         if (error.message) {
           grunt.log(error.message);
         }
         return deferred.reject();
       }
 
-      grunt.log.write(result.toString('ascii'));
-
       deferred.resolve();
+    });
+
+    ps.stdout.setEncoding('utf8');
+    ps.stderr.setEncoding('utf8');
+    ps.stdout.on('data', function(data) {
+      grunt.log.write(data);
+    });
+    ps.stderr.on('data', function(data) {
+      grunt.log.write(data);
     });
 
     return deferred.promise;


### PR DESCRIPTION
I changed the task to log output as it comes back from the spawned processes instead of when the processes exit so that this task can be used in conjunction with long running tasks like watch or a preview server.
