### PR TITLE
grunt.log.error instead of grunt.log which isn't a valid function.

### DIFF
--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       if (error || code !== 0) {
         grunt.log.error(result.stderr || result.stdout);
         if (error.message) {
-          grunt.log(error.message);
+          grunt.log.error(error.message);
         }
         return deferred.reject();
       }


### PR DESCRIPTION
Found another issue with errors. Sorry I didn't see this the first time.
