### PR TITLE
add new lines back to result so output from different tasks aren't all jumbled together.

### DIFF
--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
         return deferred.reject();
       }
 
-      grunt.log.write(result.toString('ascii'));
+      grunt.log.writeln(result.toString('ascii'));
 
       deferred.resolve();
     });


### PR DESCRIPTION
Simple change to make the resulting output more readable.

before:
![Screen Shot 2013-03-01 at 12 22 49 AM](https://f.cloud.github.com/assets/51505/208478/3ae503fa-8230-11e2-8cd9-3a3bbe5708e5.png)

after:
![Screen Shot 2013-03-01 at 12 21 44 AM](https://f.cloud.github.com/assets/51505/208479/42e21db8-8230-11e2-8a37-a5dbd0fb228b.png)
