### PR TITLE
Use stream interfaces of child processes to log to stdout/stderr

### DIFF
--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -12,19 +12,21 @@ module.exports = function(grunt) {
   function spawn(task) {
     var deferred = Q.defer();
 
-    grunt.util.spawn(task, function(error, result, code) {
-      if (error || code !== 0) {
-        grunt.log.error(result.stderr || result.stdout);
-        if (error.message) {
-          grunt.log(error.message);
-        }
-        return deferred.reject();
+    var child = grunt.util.spawn(task, function(error, result, code) {
+      if (code !== 0) {
+        !child && grunt.log.error(error);
+        deferred.reject();
       }
 
-      grunt.log.write(result.toString('ascii'));
-
-      deferred.resolve();
+      else {
+        deferred.resolve();
+      }
     });
+
+    if (child) {
+      child.stdout.on('data', function(d) { grunt.log.write(String(d)); });
+      child.stderr.on('data', function(d) { grunt.log.error(String(d)); });
+    }
 
     return deferred.promise;
   }


### PR DESCRIPTION
The current implementation won't print to stdout/stderr until the child process has finished. This pull request uses the stream interface of the child process to print to stdout/stderr on the spot.

Right now it's not as clean as it could be due to how `grunt.util.spawn` works. If this [pull request](https://github.com/gruntjs/grunt/pull/699) gets merged, I'll clean up this change accordinly.
