### PR TITLE
(#14) - pass verbose flag to tasks

### DIFF
--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -48,6 +48,15 @@ module.exports = function(grunt) {
       });
     }
 
+    // Pass verbose flag to spawned tasks
+    if (grunt.option('verbose')) {
+      this.data.tasks.forEach(function(task) {
+        if (task.grunt) {
+          task.args.push('--verbose');
+        }
+      });
+    }
+
     if (options.stream === true) {
       this.data.tasks = this.data.tasks.map(function(task) {
         task.opts = task.opts || {};


### PR DESCRIPTION
Just as required by #14.

However:
1. if we run tasks which are not grunt's then `--verbose` can have side effects like command saying that it does not know such an option
2. if we run tasks which are grunt then's `--verbose` have side effect of showing its initialization steps twice. This is, however, not that bad.

Do you want to check if task is grunt's before passing the `--verbose` flag?
