### PR TITLE
Send all flags, including verbose, to grunt tasks

### DIFF
--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -72,9 +72,11 @@ module.exports = function(grunt) {
     // Allow any flags to be passed to spawned tasks
     // This includes the verbose flag as well as any custom task flags
     this.data.tasks.forEach(function ( task ) {
-      grunt.option.flags().forEach(function ( flag ) {
-        task.args.push( flag );
-      });
+      if ( task.grunt ) {
+        grunt.option.flags().forEach(function ( flag ) {
+          task.args.push( flag );
+        });
+      }
     });
 
     Q.all(this.data.tasks.map(spawn)).then(done, done.bind(this, false));

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -41,6 +41,7 @@ module.exports = function(grunt) {
       grunt: false,
       stream: false
     });
+    var flags = grunt.flags();
 
     // If the configuration specifies that the task is a grunt task. Make it so.
     if (options.grunt === true) {
@@ -73,7 +74,7 @@ module.exports = function(grunt) {
     // This includes the verbose flag as well as any custom task flags
     this.data.tasks.forEach(function ( task ) {
       if ( task.grunt ) {
-        grunt.option.flags().forEach(function ( flag ) {
+        flags.forEach(function ( flag ) {
           task.args.push( flag );
         });
       }

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 
         grunt.log.error(message);
         lpad.stdout();
-        
+
         return deferred.reject();
       }
 
@@ -39,9 +39,9 @@ module.exports = function(grunt) {
     var done = this.async();
     var options = this.options({
       grunt: false,
-      stream: false 
+      stream: false
     });
-    
+
     // If the configuration specifies that the task is a grunt task. Make it so.
     if (options.grunt === true) {
       this.data.tasks = this.data.tasks.map(function(task) {
@@ -69,14 +69,13 @@ module.exports = function(grunt) {
       return task;
     });
 
-    // Pass verbose flag to spawned tasks
-    if (grunt.option('verbose')) {
-      this.data.tasks.forEach(function(task) {
-        if (task.grunt) {
-          task.args.push('--verbose');
-        }
+    // Allow any flags to be passed to spawned tasks
+    // This includes the verbose flag as well as any custom task flags
+    this.data.tasks.forEach(function ( task ) {
+      grunt.option.flags().forEach(function ( flag ) {
+        task.args.push( flag );
       });
-    }
+    });
 
     Q.all(this.data.tasks.map(spawn)).then(done, done.bind(this, false));
   });


### PR DESCRIPTION
This is an update to the code included in PR #20 to allow a verbose flag.  This extends that a bit and allows any flag passed to be passed on to any grunt tasks.  This still passes the verbose flag but also allows custom flags to be sent.

*My apologies for the whitespace removal lines... good 'ol ST3*