### PR TITLE
Added progress indicator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ grunt.initConfig({
 
 Since tail runs till you send it a shutdown signal, you would like to stream the output to your stdio.
 
+#### Progress indeicator
+
+If you have long running tasks, you can turn on a "progress" indicator where '.' will be spit out on task stdout to let you know work is being accomplished
+
+```javascript
+grunt.initConfig({
+  stream: {
+    options: {
+      progress: true
+    },
+    tasks: [{ cmd: 'tail', args: ['-f', '/var/log/system.log']}]
+  }
+});
+```
+
+Progress indicator does not output anything if stream == true
+
 #### Only Using Grunt
 
 If you are only going to delegate to other grunt tasks you can simply put `grunt: true` in your tasks configuration and grunt-parallel will run them all using grunt.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ grunt.initConfig({
 
 Since tail runs till you send it a shutdown signal, you would like to stream the output to your stdio.
 
-#### Progress indeicator
+#### Progress indicator
 
 If you have long running tasks, you can turn on a "progress" indicator where '.' will be spit out on task stdout to let you know work is being accomplished
 

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
   function spawn(task) {
     var deferred = Q.defer();
 
-    grunt.util.spawn(task, function(error, result, code) {
+    var spawn = grunt.util.spawn(task, function(error, result, code) {
       grunt.log.writeln();
       lpad.stdout('    ');
 
@@ -31,6 +31,11 @@ module.exports = function(grunt) {
 
       deferred.resolve();
     });
+    if (!task.stream && task.progress) {
+      spawn.stdout.on('data', function (data) {
+        grunt.log.write('.');
+      });
+    }
 
     return deferred.promise;
   }
@@ -39,6 +44,7 @@ module.exports = function(grunt) {
     var done = this.async();
     var options = this.options({
       grunt: false,
+      progress: false,
       stream: false
     });
     var flags = grunt.option.flags();
@@ -63,9 +69,11 @@ module.exports = function(grunt) {
 
       // Pipe to the parent stdout when streaming.
       if ( task.stream || ( task.stream === undefined && options.stream ) ) {
+        task.stream = true;
         task.opts = task.opts || {};
         task.opts.stdio = 'inherit';
       }
+      task.progress = task.progress || (task.progress === undefined && options.progress);
 
       return task;
     });


### PR DESCRIPTION
This option (default = false) will cause '.' to be spit out on any stdout output. This is incredibly useful for long running processes to give you an indication that stuff is actually happening. Does not do anything if stream == true.

With new and improved correctly spelled Readme for new option