### PR TITLE
Overtake grunt.config properties to spawned childs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ grunt.initConfig({
 
 One might target the task using `grunt parallel:assets`. This would run compass, requirejs, and a custom shell script at the same time, each logging to your console when they are done.
 
+#### Overtaking config properties
+
+Sometimes you want some properties from grunt.config to persist in the spawned task. To do this you can put `config: <Array of config props>` in your tasks configuration, and grunt-parallel will apply the given properties to the spawned grunt process.
+This will only work with grunt processes!
+Length is somehow limited, because command line parameters were used!
+This works only from the main process to the spawned childrens. Changing the config within one child will not have any effect to the config within other childs or the main pricess.
+
 ## License
 Copyright (c) 2013 Merrick Christensen
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ grunt.initConfig({
   parallel: {
     assets: {
       options: {
-        grunt: true.
+        grunt: true,
         options: ['domain']
       },
       tasks: ['fast', 'block', 'fast']

--- a/README.md
+++ b/README.md
@@ -142,26 +142,26 @@ grunt.initConfig({
   },
   
   uglify: {
-      options: {
-        banner: "/* GIT HEAD is <%= git_head %> */"
-      },
+    options: {
+      banner: "/* GIT HEAD is <%= git_head %> */"
+    },
 
-      task1: {
-        src: "dist/app.js",
-        dest: "dist/app.min.js"
-      },
-      task2: {
-        src: "dist/ux.js",
-        dest: "dist/ux.min.js"
-      }
+    task1: {
+      src: "dist/app.js",
+      dest: "dist/app.min.js"
+    },
+    task2: {
+      src: "dist/ux.js",
+      dest: "dist/ux.min.js"
     }
+  }
 });
 
 grunt.registerMultiTask('git_get_head', 'get git HEAD hash', function() {
-    grunt.config.set('git_head', String(child_process.execFileSync(
-                                     'git', 
-                                     ["rev-parse", "HEAD"]
-                                 )).split("\n")[0]);
+  grunt.config.set('git_head', String(child_process.execFileSync(
+                                   'git', 
+                                   ["rev-parse", "HEAD"]
+                               )).split("\n")[0]);
 });
 
 /* get git head once, expose it to spawned childs */

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ grunt.initConfig({
     }
   }
 });
+```
 
 ## License
 Copyright (c) 2013 Merrick Christensen

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ This will only work with grunt processes!
 Length is somehow limited, because command line parameters were used!
 This works only from the main process to the spawned childrens. Changing the config within one child will not have any effect to the config within other childs or the main pricess.
 
+```javascript
+
+grunt.initConfig({
+  domain: "foo",
+  
+  parallel: {
+    assets: {
+      options: {
+        grunt: true.
+        options: ['domain']
+      },
+      tasks: ['fast', 'block', 'fast']
+    }
+  }
+});
+
 ## License
 Copyright (c) 2013 Merrick Christensen
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ One might target the task using `grunt parallel:assets`. This would run compass,
 
 #### Expose grunt.config properties
 
-Sometimes you want some properties from grunt.config to persist in the spawned task. To do this you can put `exposeGruntConfigKeys: <Array of config props>` in your tasks configuration, and grunt-parallel will apply the given properties to the spawned grunt process.
+While constant config values are always available to spawned subtasks, sometimes config properties were changed dynamically by other tasks. You can expose this config properties to the spawned tasks by putting `exposeGruntConfigKeys: <Array of config props>` in your tasks configuration, and grunt-parallel will apply the given properties to the spawned grunt process.
 * This will only work with grunt processes!
 * Length may be somehow limited, because command line parameters were used!
 * This works only from the main process to the spawned childrens. Changing the config within one child will not have any effect to the config within other childs or the main pricess.
@@ -158,10 +158,10 @@ grunt.initConfig({
 });
 
 grunt.registerMultiTask('git_get_head', 'get git HEAD hash', function() {
-        grunt.config.set('git_head', String(child_process.execFileSync(
-                                        'git', 
-                                        ["rev-parse", "HEAD"]
-                                     )).split("\n")[0]);
+    grunt.config.set('git_head', String(child_process.execFileSync(
+                                     'git', 
+                                     ["rev-parse", "HEAD"]
+                                 )).split("\n")[0]);
 });
 
 /* get git head once, expose it to spawned childs */

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
   if (config) {
         // merge back in config properties
         try {
-            var configObj=JSON.parse(config);
+            var configObj = JSON.parse(config);
             grunt.config.merge(configObj);
             
         } catch(e) {}

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -9,6 +9,18 @@
 module.exports = function(grunt) {
   var Q = require('q');
   var lpad = require('lpad');
+  
+  var config = grunt.option('parallelconfig') || null;
+  if (config) {
+        // merge back in config properties
+        try {
+            var configObj=JSON.parse(config);
+            grunt.config.merge(configObj);
+            
+        } catch(e) {}
+    }
+  
+  
 
   function spawn(task) {
     var deferred = Q.defer();
@@ -39,7 +51,8 @@ module.exports = function(grunt) {
     var done = this.async();
     var options = this.options({
       grunt: false,
-      stream: false
+      stream: false,
+      config: false
     });
     var flags = grunt.option.flags();
 
@@ -52,6 +65,19 @@ module.exports = function(grunt) {
         }
       });
     }
+    
+    if (options.config) {
+        // overtake some properties from the grunt config object (will be merged back again after this module loads)
+        var configObj={};
+        options.config.forEach(function ( configProp ) {
+            configObj[configProp] = grunt.config.get(configProp);
+        });
+        
+        flags.push('--parallelconfig=' + JSON.stringify(configObj));
+    }
+    
+    
+    
 
     // Normalize tasks config.
     this.data.tasks = this.data.tasks.map(function(task) {

--- a/tasks/parallel.js
+++ b/tasks/parallel.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
     var options = this.options({
       grunt: false,
       stream: false,
-      config: false
+      exposeGruntConfigKeys: false
     });
     var flags = grunt.option.flags();
 
@@ -66,13 +66,14 @@ module.exports = function(grunt) {
       });
     }
     
-    if (options.config) {
-        // overtake some properties from the grunt config object (will be merged back again after this module loads)
-        var configObj={};
-        options.config.forEach(function ( configProp ) {
+    // If the configuration specifies that grunt.config keys should be exposed to the spawned processes, make it so.
+    if (options.exposeGruntConfigKeys !== false) {
+        var configObj = {};
+        options.exposeGruntConfigKeys.forEach(function(configProp) {
             configObj[configProp] = grunt.config.get(configProp);
         });
         
+        // value of the parallelconfig param will be merged back again after this module loads
         flags.push('--parallelconfig=' + JSON.stringify(configObj));
     }
     


### PR DESCRIPTION
Sometimes you want some properties from grunt.config to persist in the spawned task. To do this you can put config: <Array of config props> in your tasks configuration, and grunt-parallel will apply the given properties to the spawned grunt process.